### PR TITLE
<fr>Made colonyMinerals array to display less purchases

### DIFF
--- a/scripts/database.js
+++ b/scripts/database.js
@@ -48,10 +48,6 @@ facilityMinerals: [
 //create colonyMinerals array
 colonyMinerals: [
     {id:1, colonyId:2, mineralId:1, quantity: 85},
-    {id:2, colonyId:1, mineralId:4, quantity: 185},
-    {id:3, colonyId:6, mineralId:3, quantity: 250},
-    {id:4, colonyId:5, mineralId:2, quantity: 850},
-    {id:5, colonyId:4, mineralId:4, quantity: 150}
 ],
 
 transientState: {}


### PR DESCRIPTION
# Description

We needed fewer purchases made by colonies in our colonyMinerals array, so I removed four of them

Fixes # (issue)
No fixes
## Type of change
Feature change to get rid of purchases in colonyMinerals array

- [ ] New feature (non-breaking change which adds functionality)
